### PR TITLE
Changed helm lint command to use specific chart archive name

### DIFF
--- a/pre_commit_flux/check_flux_helm_values.py
+++ b/pre_commit_flux/check_flux_helm_values.py
@@ -70,7 +70,7 @@ def _validateFile(fileToValidate, repos):
                     exit(1)
 
                 res = subprocess.run(
-                    "helm lint -f values.yaml *.tgz",
+                    "helm lint -f values.yaml \"{quote(chartName)}-{quote(chartVersion)}.tgz\"",
                     shell=True,
                     cwd=tmpDir,
                     text=True,


### PR DESCRIPTION
I'm running this locally but I can't 100% guarantee that this will match every Helm chart artifact file name. Can anybody confirm if Helm can return a different format (i.e. underscore instead of dash, .tar.gz instead of .tgz)?