### PR TITLE
Add kustomize overlay support using the flux-local library

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     args: ['--fix=auto']  # replace 'auto' with 'lf' to enforce Linux/Mac line endings or 'crlf' for Windows
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
   - id: isort
 

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@
     -   id: check-flux-helm-values
 ```
 
-The hook depends on the helm binary being available in the path (but it doesn't require to be able to connect to a cluster).
+The hook depends on the kustomize and helm binaries being available in the path (but it doesn't require to be able to connect to a cluster). The hook will first verify the flux Kustomizations are correct using `kustomize build` and supports repos with multiple clusters and overlays. The second step is to run `helm template` for all changed HelmReleases in the cluster to verify they can be built. The flux Kustomization path can be configured with a `--path` or otherwhise will attempt to find any Kustomziations in the repo.

--- a/pre_commit_flux/check_flux_helm_values.py
+++ b/pre_commit_flux/check_flux_helm_values.py
@@ -1,100 +1,134 @@
-import glob
-import os.path as path
-import subprocess
-import sys
+import argparse
+import asyncio
+import dataclasses
 import tempfile
-from shlex import quote
+from pathlib import Path
 
 import yaml
+from flux_local import git_repo
+from flux_local.command import CommandException
+from flux_local.helm import Helm
 
 errors: list = []
 
 
+@dataclasses.dataclass(frozen=True)
+class Name:
+    namespace: str
+    name: str
+
+    def __repr__(self) -> str:
+        return f"{self.namespace}/{self.name}"
+
+
 def main():
-    repos = _buildRepoMap()
-    for arg in sys.argv[1:]:
-        try:
-            _validateFile(arg, repos)
-        except Exception as ex:
-            _collectErrors({"source": arg, "message": f"{type(ex).__name__} {ex.args}"})
+    asyncio.run(_asyncMain())
     if len(errors) > 0:
         _printErrors()
         exit(1)
 
 
-def _buildRepoMap():
-    repos = {}
-    for file in glob.glob("./**/*.yaml", recursive=True):
-        with open(file) as f:
-            try:
-                for definition in yaml.load_all(f, Loader=yaml.SafeLoader):
-                    if (
-                        not definition
-                        or "kind" not in definition
-                        or definition["kind"] != "HelmRepository"
-                    ):
-                        continue
-                    repoName = definition["metadata"]["name"]
-                    repos[repoName] = definition["spec"]["url"]
-            except Exception:
-                continue
+async def _asyncMain():
+    parser = argparse.ArgumentParser(
+        description="Command line utility for inspecting a local flux repository.",
+    )
+    parser.add_argument(
+        "filename",
+        nargs="+",
+    )
+    parser.add_argument(
+        "--path",
+        type=Path,
+        help="Path to the flux cluster kustomization (optional)",
+        required=False,
+    )
+    args = parser.parse_args()
 
-    return repos
+    release_names = set({})
+    for arg in args.filename:
+        try:
+            if release_name := _getReleaseName(arg):
+                release_names.add(release_name)
+        except ValueError as err:
+            _collectErrors({"source": arg, "message": str(err)})
+    try:
+        await _validateReleases(release_names, args.path)
+    except Exception as err:
+        import traceback
+
+        traceback.print_exc()
+        _collectErrors({"source": "validateReleases", "message": str(err)})
 
 
-def _validateFile(fileToValidate, repos):
+def _getReleaseName(fileToValidate: str) -> Name | None:
+    """Return a namespace and name if valid HelmRelease yaml file."""
     with open(fileToValidate) as f:
         for definition in yaml.load_all(f, Loader=yaml.SafeLoader):
-            if (
-                not definition
-                or "kind" not in definition
-                or definition["kind"] != "HelmRelease"
-            ):
-                continue
+            if not definition or definition.get("kind") != "HelmRelease":
+                return None
+        if not (metadata := definition.get("metadata")):
+            raise ValueError(f"Invalid HelmRelease missing metadata: {definition}")
+        if not (name := metadata.get("name")):
+            raise ValueError(f"Invalid HelmRelease missing metadata.name: {definition}")
+        if not (namespace := metadata.get("namespace")):
+            raise ValueError(
+                f"Invalid HelmRelease missing metadata.namespace: {definition}"
+            )
+        return Name(namespace, name)
 
-            chartSpec = definition["spec"]["chart"]["spec"]
 
-            if chartSpec["sourceRef"]["kind"] != "HelmRepository":
-                continue
+async def _validateReleases(release_names: set[Name], path: Path | None) -> None:
+    manifest = await git_repo.build_manifest(path=path)
+    releases = [
+        release
+        for cluster in manifest.clusters
+        for release in cluster.helm_releases
+        if Name(release.namespace, release.name) in release_names
+    ]
+    if not releases:
+        _collectErrors(
+            {
+                "source": "kustomize build",
+                "message": f"HelmRelease files not found in Kustomizations: {release_names}",
+            }
+        )
+        return
 
-            chartName = chartSpec["chart"]
-            chartVersion = chartSpec["version"]
-            chartUrl = repos[chartSpec["sourceRef"]["name"]]
+    # Prune HelmRepository objects to just the active referenced by a HelmRelease
+    active_repo_names = {
+        Name(release.chart.repo_namespace, release.chart.repo_name)
+        for release in releases
+    }
+    repos = [
+        repo
+        for cluster in manifest.clusters
+        for repo in cluster.helm_repos
+        if Name(repo.namespace, repo.name) in active_repo_names
+    ]
 
-            with tempfile.TemporaryDirectory() as tmpDir:
-                with open(path.join(tmpDir, "values.yaml"), "w") as valuesFile:
-                    if "spec" in definition and "values" in definition["spec"]:
-                        yaml.dump(definition["spec"]["values"], valuesFile)
+    with tempfile.TemporaryDirectory() as tmpDir:
+        helm = Helm(Path(tmpDir), cache_dir=Path(tmpDir))
+        helm.add_repos(repos)
 
-                res = subprocess.run(
-                    f"helm pull --repo {quote(chartUrl)} --version {quote(chartVersion)} {quote(chartName)}",
-                    shell=True,
-                    cwd=tmpDir,
-                    text=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
+        try:
+            await helm.update()
+        except CommandException as err:
+            _collectErrors({"source": "helm pull", "message": str(err)})
+            return
+
+        for release in releases:
+            try:
+                await helm.template(release)
+            except CommandException as err:
+                _collectErrors(
+                    {
+                        "source": "helm template {release.release_name}",
+                        "message": str(err),
+                    }
                 )
-                if res.returncode != 0:
-                    _collectErrors(
-                        {"source": "helm pull", "message": f"\n{res.stdout}"}
-                    )
-                    continue
-
-                res = subprocess.run(
-                    "helm lint -f values.yaml *.tgz",
-                    shell=True,
-                    cwd=tmpDir,
-                    text=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                )
-                if res.returncode != 0:
-                    _collectErrors(
-                        {"source": "helm lint", "message": f"\n{res.stdout}"}
-                    )
 
 
-def _collectErrors(error):
+def _collectErrors(error: dict[str, str]):
     errors.append(error)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+flux-local==0.10.0
 pyyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ packages = find:
 python_requires = >= 3.8.5
 install_requires =
     pyyaml
-    flux-local==0.10.0
+    flux-local>=1.0.1
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ packages = find:
 python_requires = >= 3.8.5
 install_requires =
     pyyaml
+    flux-local==0.10.0
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This will add a step that ensures that all kustomizations in the cluster can be built, then runs `helm template` on the changed HelmReleases.  The flux-local library works by using `kustomize build` and `kustomize cfg grep` etc to walk through all fluxtomizations, then build any regular kustomizations inside. This allows `flux-check-hook` to work when a `HelmRelease` specified with an overlay where the yaml that changed may not have enough information to build it.

Issue #6

Update isort to avoid the problem:
```
RuntimeError: The Poetry configuration is invalid:
        - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
```

Note: flux-local is not at all widely used, so it would be worth additional eyes to test if this works on your repo. I've tested on a few in the k8s-at-home community.