### PR TITLE
Fix validation for OCI repos

### DIFF
--- a/pre_commit_flux/check_flux_helm_values.py
+++ b/pre_commit_flux/check_flux_helm_values.py
@@ -66,8 +66,13 @@ def _validateFile(fileToValidate, repos):
                     if "spec" in definition and "values" in definition["spec"]:
                         yaml.dump(definition["spec"]["values"], valuesFile)
 
+                if chartUrl.startswith("oci://"):
+                    chartOciUrl = f"{chartUrl}{'' if chartUrl.endswith('/') else '/'}{chartName}"
+                    command = f"helm pull {quote(chartOciUrl)} --version {quote(chartVersion)}"
+                else:
+                    command = f"helm pull --repo {quote(chartUrl)} --version {quote(chartVersion)} {quote(chartName)}"
                 res = subprocess.run(
-                    f"helm pull --repo {quote(chartUrl)} --version {quote(chartVersion)} {quote(chartName)}",
+                    command,
                     shell=True,
                     cwd=tmpDir,
                     text=True,


### PR DESCRIPTION
When the HelmRepository is of type oci, the `helm pull` command must follow a different syntax.